### PR TITLE
Primitive implementation of backend/dockerfile

### DIFF
--- a/lib/configspec/backend.rb
+++ b/lib/configspec/backend.rb
@@ -1,3 +1,4 @@
 require 'configspec/backend/base'
 require 'configspec/backend/ssh'
 require 'configspec/backend/exec'
+require 'configspec/backend/dockerfile'

--- a/lib/configspec/backend/dockerfile.rb
+++ b/lib/configspec/backend/dockerfile.rb
@@ -1,0 +1,20 @@
+require 'singleton'
+
+module Configspec
+  module Backend
+    class Dockerfile < Base
+      def initialize
+        @lines = []
+        ObjectSpace.define_finalizer(self) {
+          File.write("Dockerfile", @lines.join("\n"))
+        }
+      end
+
+      def run_command(cmd, opts={})
+        @lines << "RUN #{cmd}"
+        { :stdout => nil, :stderr => nil,
+          :exit_status => 0, :exit_signal => nil }
+      end
+    end
+  end
+end

--- a/lib/configspec/helper.rb
+++ b/lib/configspec/helper.rb
@@ -1,5 +1,6 @@
 require 'configspec/helper/exec'
 require 'configspec/helper/ssh'
+require 'configspec/helper/dockerfile'
 require 'configspec/helper/detect_os'
 require 'configspec/helper/redhat'
 

--- a/lib/configspec/helper/dockerfile.rb
+++ b/lib/configspec/helper/dockerfile.rb
@@ -1,0 +1,14 @@
+module Configspec
+  module Helper
+    module Dockerfile
+      def backend(commands_object=nil)
+        if commands_object.nil? && ! respond_to?(:commands)
+          commands_object = Configspec::Commands::Base.new
+        end
+        instance = Configspec::Backend::Dockerfile.instance
+        instance.set_commands(commands_object || commands)
+        instance
+      end
+    end
+  end
+end


### PR DESCRIPTION
This pull request generates Dockerfile with this spec_helper.

``` ruby
require 'configspec'

include Configspec::Helper::Dockerfile
include Configspec::Helper::RedHat
```
