### PR TITLE
You can set "FROM" to Dockerfile with this patch.

### DIFF
--- a/lib/configspec/backend/dockerfile.rb
+++ b/lib/configspec/backend/dockerfile.rb
@@ -15,6 +15,10 @@ module Configspec
         { :stdout => nil, :stderr => nil,
           :exit_status => 0, :exit_signal => nil }
       end
+
+      def from(base)
+        @lines << "FROM #{base}"
+      end
     end
   end
 end

--- a/lib/configspec/helper/type.rb
+++ b/lib/configspec/helper/type.rb
@@ -1,7 +1,7 @@
 module Configspec
   module Helper
     module Type
-      types = %w( base package )
+      types = %w( base package dockerfile )
 
       types.each {|type| require "configspec/type/#{type}" }
 

--- a/lib/configspec/type/dockerfile.rb
+++ b/lib/configspec/type/dockerfile.rb
@@ -1,0 +1,13 @@
+module Configspec
+  module Type
+    class Dockerfile < Base
+      def from?(base)
+        backend.from(base)
+      end
+
+      def to_s
+        "Dockerfile"
+      end
+    end
+  end
+end


### PR DESCRIPTION
You can specify the base image of Docker VM written in Dockerfile like this.

``` ruby
describe dockerfile do
  it { should be_from 'centos' }
end
```
