### PR TITLE
Added basic configuration of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+rvm:
+  - 1.9.3
+  - 2.0.0
+
+script: rake spec

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require "bundler/gem_tasks"
 require 'rspec/core/rake_task'
 
+task :default => :spec
 task :spec => 'spec:redhat'
 
 namespace :spec do


### PR DESCRIPTION
travis でテストが失敗しているので、.travis.yml の標準的な設定を追加することでテストが失敗するという現象を直しました。
