### PR TITLE
ssh copy_file

### DIFF
--- a/configspec.gemspec
+++ b/configspec.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "net-ssh"
+  spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "rspec", ">= 2.13.0"
   spec.add_runtime_dependency "specinfra", ">= 0.0.6"
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lib/configspec/setup.rb
+++ b/lib/configspec/setup.rb
@@ -207,6 +207,7 @@ require 'pathname'
 <% end -%>
 <% if @backend_type == 'Ssh' -%>
 require 'net/ssh'
+require 'net/scp'
 <% end -%>
 <% if @backend_type == 'WinRM' -%>
 require 'winrm'
@@ -242,6 +243,7 @@ RSpec.configure do |c|
     host  = File.basename(Pathname.new(file).dirname)
     if c.host != host
       c.ssh.close if c.ssh
+      c.scp.close if c.scp
       c.host  = host
       options = Net::SSH::Config.for(c.host)
       user    = options[:user] || Etc.getlogin
@@ -263,6 +265,7 @@ RSpec.configure do |c|
       end
     <%- end -%>
       c.ssh   = Net::SSH.start(host, user, options)
+      c.scp   = Net::SCP.start(host, user, options)
     end
   end
   <%- end -%>


### PR DESCRIPTION
Continued from https://github.com/serverspec/configspec/pull/9

``` ruby
describe file('remote_file') do
  it { should be_sourced_from 'local_file' }
end
```

for SSH case is implemented now. 

https://github.com/serverspec/specinfra/pull/33 is required. 

EDIT: Fixed the describe example. 
