### PR TITLE
Fix "uninitialized constant Configspec::Helper::Dockerfile (NameError)"

### DIFF
--- a/lib/configspec/setup.rb
+++ b/lib/configspec/setup.rb
@@ -214,7 +214,7 @@ require 'winrm'
 <% end -%>
 
 <% if @backend_type == 'Dockerfile' -%>
-include Configspec::Helper::<%= @backend_type %>
+include SpecInfra::Helper::<%= @backend_type %>
 <% else -%>
 include SpecInfra::Helper::<%= @backend_type %>
 <% end -%>


### PR DESCRIPTION
I have tried configspec-init with Dockerfile, it didn't work. This will fix for it.

```
/Users/gabu/.rbenv/versions/2.0.0-p353/bin/ruby -S rspec
/Users/gabu/git/dev/configspec/hello/spec/spec_helper.rb:3:in `<top (required)>': uninitialized constant Configspec::Helper::Dockerfile (NameError)
    from /Users/gabu/git/dev/configspec/hello/spec/001_httpd_spec.rb:1:in `require'
    from /Users/gabu/git/dev/configspec/hello/spec/001_httpd_spec.rb:1:in `<top (required)>'
    from /Users/gabu/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load'
    from /Users/gabu/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `block in load_spec_files'
    from /Users/gabu/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `each'
    from /Users/gabu/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-core-2.14.8/lib/rspec/core/configuration.rb:896:in `load_spec_files'
    from /Users/gabu/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-core-2.14.8/lib/rspec/core/command_line.rb:22:in `run'
    from /Users/gabu/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:80:in `run'
    from /Users/gabu/.rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-core-2.14.8/lib/rspec/core/runner.rb:17:in `block in autorun'
/Users/gabu/.rbenv/versions/2.0.0-p353/bin/ruby -S rspec failed
```
